### PR TITLE
Include unsubscribe link in failure/recovery email

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -64,16 +64,21 @@ function sendRecoveryEmail(displayId, addresses) {
 function prepareAndSendEmail(template, displayId, recipients) {
   const subject = template.subject.replace('DISPLAYID', displayId);
   const text = template.body.replace(/DISPLAYID/g, displayId);
+  const promises = [];
 
-  const data = {
-    from: SENDER_ADDRESS,
-    fromName: SENDER_NAME,
-    recipients,
-    subject,
-    text
-  };
+  recipients.forEach(recipient=>{
+    const data = {
+      from: SENDER_ADDRESS,
+      fromName: SENDER_NAME,
+      recipients: recipient,
+      subject,
+      text: text.replace("EMAIL", recipient)
+    };
 
-  return send(data);
+    promises.push(send(data));
+  });
+
+  return Promise.all(promises);
 }
 
 function send(data) {
@@ -81,13 +86,12 @@ function send(data) {
   const url = `${EMAIL_API_URL}?${parameterString}`;
 
   return got.post(url)
-  .then(response =>
-  {
+  .then(response => {
     if (response.statusCode !== RESPONSE_OK) {
       return logErrorDataFor(response, url);
     }
 
-    console.log(`Mail '${data.subject}' sent to ${data.recipients.join()}`);
+    console.log(`Mail '${data.subject}' sent to ${data.recipient}`);
 
     return JSON.parse(response.body);
   });

--- a/src/templates/failure.txt
+++ b/src/templates/failure.txt
@@ -1,1 +1,3 @@
 The display with display id 'DISPLAYID' has gone offline.
+
+If you no longer wish to receive these notices, you can <a href="http://rvaserver2/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.

--- a/src/templates/failure.txt
+++ b/src/templates/failure.txt
@@ -1,3 +1,3 @@
 The display with display id 'DISPLAYID' has gone offline.
 
-If you no longer wish to receive these notices, you can <a href="http://rvaserver2/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.
+If you no longer wish to receive these notices, you can <a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.

--- a/src/templates/recovery.txt
+++ b/src/templates/recovery.txt
@@ -1,1 +1,3 @@
 The display with display id 'DISPLAYID' has come back online.
+
+If you no longer wish to receive these notices, you can <a href="http://rvaserver2/monitoring/unsubscribe?email=EMAIL&id=ID>unsubscribe</a>.

--- a/src/templates/recovery.txt
+++ b/src/templates/recovery.txt
@@ -1,3 +1,3 @@
 The display with display id 'DISPLAYID' has come back online.
 
-If you no longer wish to receive these notices, you can <a href="http://rvaserver2/monitoring/unsubscribe?email=EMAIL&id=ID>unsubscribe</a>.
+If you no longer wish to receive these notices, you can <a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -80,7 +80,7 @@ describe("Notifier - Unit", () => {
     return notifier.sendFailureEmail('ABC', ['a@example.com', 'b@example.com'])
     .then(() => {
       assert(got.post.called);
-      assert.equal(got.post.callCount, 1);
+      assert.equal(got.post.callCount, 2);
 
       const url = got.post.lastCall.args[0];
 
@@ -91,7 +91,7 @@ describe("Notifier - Unit", () => {
 
       assert.equal(parameters.from, "support@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
-      assert.deepEqual(parameters.recipients, ['a@example.com', 'b@example.com']);
+      assert.deepEqual(parameters.recipients, 'b@example.com');
       assert.equal(parameters.subject, "Display ABC is offline");
       assert.equal(typeof parameters.text, "string");
       assert(parameters.text.indexOf("ABC") > 0);

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -91,7 +91,7 @@ describe("Notifier - Unit", () => {
 
       assert.equal(parameters.from, "support@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
-      assert.deepEqual(parameters.recipients, 'b@example.com');
+      assert.equal(parameters.recipients, 'b@example.com');
       assert.equal(parameters.subject, "Display ABC is offline");
       assert.equal(typeof parameters.text, "string");
       assert(parameters.text.indexOf("ABC") > 0);


### PR DESCRIPTION
The email templates are now unique per addressee and display id, so we can't send
multiple recipients the same email.