### PR TITLE
use same summary line for failure and recovery mails

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -8,16 +8,11 @@ const EMAIL_API_URL = "https://rvaserver2.appspot.com/_ah/api/rise/v0/email";
 const SENDER_ADDRESS = "support@risevision.com";
 const SENDER_NAME = "Rise Vision Support";
 const RESPONSE_OK = 200;
+const SUBJECT_LINE = "Display monitoring for display DISPLAYID";
 
 const templates = {
-  "failure": {
-    "subject": "Display DISPLAYID is offline",
-    "body": loadTemplate("failure")
-  },
-  "recovery": {
-    "subject": "Display DISPLAYID is now online",
-    "body": loadTemplate("recovery")
-  }
+  "failure": loadTemplate("failure"),
+  "recovery": loadTemplate("recovery")
 };
 
 function loadTemplate(name) {
@@ -62,8 +57,8 @@ function sendRecoveryEmail(displayId, addresses) {
 }
 
 function prepareAndSendEmail(template, displayId, recipients) {
-  const subject = template.subject.replace('DISPLAYID', displayId);
-  const text = template.body.replace(/DISPLAYID/g, displayId);
+  const subject = SUBJECT_LINE.replace('DISPLAYID', displayId);
+  const text = template.replace(/DISPLAYID/g, displayId);
   const promises = [];
 
   recipients.forEach(recipient=>{

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -92,7 +92,7 @@ describe("Notifier - Unit", () => {
       assert.equal(parameters.from, "support@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'b@example.com');
-      assert.equal(parameters.subject, "Display ABC is offline");
+      assert.equal(parameters.subject, "Display monitoring for display ABC");
       assert.equal(typeof parameters.text, "string");
       assert(parameters.text.indexOf("ABC") > 0);
     });
@@ -119,7 +119,7 @@ describe("Notifier - Unit", () => {
       assert.equal(parameters.from, "support@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'd@example.com');
-      assert.equal(parameters.subject, "Display DEF is now online");
+      assert.equal(parameters.subject, "Display monitoring for display DEF");
       assert.equal(typeof parameters.text, "string");
       assert(parameters.text.indexOf("DEF") > 0);
     });


### PR DESCRIPTION
As stated here: https://trello.com/c/ayuUxNXe/3933-1-use-same-subject-for-display-monitoring-failure-and-recovery-messages