### PR TITLE
Feature/use ux templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,11 @@
         "assert-plus": "1.0.0"
       }
     },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^1.0.0",
+    "dateformat": "^3.0.3",
     "got": "^8.0.3",
     "redis": "^2.8.0"
   }

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -6,7 +6,7 @@ const querystring = require("querystring");
 const stateManager = require("./state-manager");
 
 const EMAIL_API_URL = "https://rvaserver2.appspot.com/_ah/api/rise/v0/email";
-const SENDER_ADDRESS = "support@risevision.com";
+const SENDER_ADDRESS = "monitor@risevision.com";
 const SENDER_NAME = "Rise Vision Support";
 const RESPONSE_OK = 200;
 const SUBJECT_LINE = "Display monitoring for display DISPLAYID";

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -7,7 +7,7 @@ const querystring = require("querystring");
 const stateManager = require("./state-manager");
 
 const EMAIL_API_URL = "https://rvaserver2.appspot.com/_ah/api/rise/v0/email";
-const SENDER_ADDRESS = "monitor@risevision.com";
+const SENDER_ADDRESS = "support@risevision.com";
 const SENDER_NAME = "Rise Vision Support";
 const RESPONSE_OK = 200;
 const SUBJECT_LINE = "Display monitoring for display DISPLAYID";
@@ -101,7 +101,7 @@ function prepareAndSendEmail(template, display, recipients) {
         text: text.replace("EMAIL", recipient)
       }
     };
-
+console.log(JSON.stringify(options.body))
     return send(data, options);
   });
 

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -58,7 +58,12 @@ function sendRecoveryEmail(display, addresses) {
   return prepareAndSendEmail(templates.recovery, display, addresses);
 }
 
-function displayDateFor(display, serverDate = new Date()) {
+function getServerDate() {
+  return new Date();
+}
+
+function displayDateFor(display) {
+  const serverDate = module.exports.getServerDate();
   const offset = display.timeZoneOffset || 0;
 
   const serverOffset = serverDate.getTimezoneOffset() * ONE_MINUTE
@@ -132,6 +137,7 @@ function logErrorDataFor(response, url) {
 
 module.exports = {
   displayDateFor,
+  getServerDate,
   sendFailureEmail,
   sendRecoveryEmail,
   updateDisplayStatusListAndNotify

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -73,7 +73,7 @@ function displayDateFor(display) {
   return new Date(utc.getTime() + displayOffset);
 }
 
-function replace(text, display, displayDate) {
+function replaceDisplayData(text, display, displayDate) {
   const formattedTimestamp =
     dateFormat(displayDate, "mmm dd yyyy, 'at' HH:MMTT");
 
@@ -84,8 +84,8 @@ function replace(text, display, displayDate) {
 
 function prepareAndSendEmail(template, display, recipients) {
   const displayDate = displayDateFor(display);
-  const subject = replace(SUBJECT_LINE, display, displayDate);
-  const text = replace(template, display, displayDate);
+  const subject = replaceDisplayData(SUBJECT_LINE, display, displayDate);
+  const text = replaceDisplayData(template, display, displayDate);
 
   const promises = recipients.map(recipient=>{
     const data = {
@@ -138,6 +138,7 @@ function logErrorDataFor(response, url) {
 module.exports = {
   displayDateFor,
   getServerDate,
+  replaceDisplayData,
   sendFailureEmail,
   sendRecoveryEmail,
   updateDisplayStatusListAndNotify

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -101,7 +101,7 @@ function prepareAndSendEmail(template, display, recipients) {
         text: text.replace("EMAIL", recipient)
       }
     };
-console.log(JSON.stringify(options.body))
+
     return send(data, options);
   });
 

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -35,11 +35,11 @@ function updateDisplayStatusListAndNotify(list) {
       switch (action) {
         case "SEND_FAILURE_EMAIL":
           logger.log(`Sending failure email to ${addresses} for ${displayId}`);
-          return module.exports.sendFailureEmail(displayId, addresses);
+          return module.exports.sendFailureEmail(display, addresses);
 
         case "SEND_RECOVERY_EMAIL":
           logger.log(`Sending recovery email to ${addresses} for ${displayId}`);
-          return module.exports.sendRecoveryEmail(displayId, addresses);
+          return module.exports.sendRecoveryEmail(display, addresses);
 
         default:
       }
@@ -48,20 +48,24 @@ function updateDisplayStatusListAndNotify(list) {
   }, Promise.resolve());
 }
 
-function sendFailureEmail(displayId, addresses) {
-  return prepareAndSendEmail(templates.failure, displayId, addresses);
+function sendFailureEmail(display, addresses) {
+  return prepareAndSendEmail(templates.failure, display, addresses);
 }
 
-function sendRecoveryEmail(displayId, addresses) {
-  return prepareAndSendEmail(templates.recovery, displayId, addresses);
+function sendRecoveryEmail(display, addresses) {
+  return prepareAndSendEmail(templates.recovery, display, addresses);
 }
 
-function prepareAndSendEmail(template, displayId, recipients) {
-  const subject = SUBJECT_LINE.replace('DISPLAYID', displayId);
-  const text = template.replace(/DISPLAYID/g, displayId);
-  const promises = [];
+function replace(text, display) {
+  return text.replace(/DISPLAYID/g, display.displayId)
+  .replace(/DISPLAYNAME/g, display.displayName)
+}
 
-  recipients.forEach(recipient=>{
+function prepareAndSendEmail(template, display, recipients) {
+  const subject = replace(SUBJECT_LINE, display);
+  const text = replace(template, display);
+
+  const promises = recipients.map(recipient=>{
     const data = {
       from: SENDER_ADDRESS,
       fromName: SENDER_NAME,
@@ -76,7 +80,7 @@ function prepareAndSendEmail(template, displayId, recipients) {
       }
     };
 
-    promises.push(send(data, options));
+    return send(data, options);
   });
 
   return Promise.all(promises)

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -75,7 +75,7 @@ function displayDateFor(display) {
 
 function replace(text, display, displayDate) {
   const formattedTimestamp =
-    dateFormat(displayDate, 'mmm dd yyyy, "at" HH:MMTT');
+    dateFormat(displayDate, "mmm dd yyyy, 'at' HH:MMTT");
 
   return text.replace(/DISPLAYID/g, display.displayId)
   .replace(/DISPLAYNAME/g, display.displayName)

--- a/src/templates/failure.txt
+++ b/src/templates/failure.txt
@@ -1,3 +1,0 @@
-The display with display id 'DISPLAYID' has gone offline.
-
-If you no longer wish to receive these notices, you can <a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.

--- a/src/templates/monitor-offline-email.html
+++ b/src/templates/monitor-offline-email.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width"/>
+</head>
+<body>
+  <div style="background:#f9f9f9;margin:0px;padding:20px" bgcolor="f9f9f9">
+      <table cellspacing="0" border="0" cellpadding="0" align="center" width="595" bgcolor="white" style="border-collapse:separate;border-spacing:0;font-family:Helvetica,Arial,sans-serif;letter-spacing:0;table-layout:fixed">
+          <tbody>
+              <tr>
+                  <td style="border:1px solid #dddddd;border-radius:2px;font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:40px 60px">
+                      <table width="100%" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:0;text-align:center" align="left">
+                                      <img src="https://ci4.googleusercontent.com/proxy/tIn39Uu_-8P30B-NjHrQ6M6cn10CNDo8yKsbzHxTVxQDdshB0RN9KmjFHpgXqGvxfJy7jhFQFRMnvpkBo-cGxyTaPHX-YnB8cvvmC5v4FbYHFSbiRAgMRCOGqol3psI81bf9vVzerfYrewyW=s0-d-e1-ft#http://s3.amazonaws.com/Rise-Images/UI/logo.svg" width="165" height="62" style="padding:15px 0 30px;text-align:left" class="CToWUd">
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table width="100%" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="color:#525252;font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:22px;padding:0">
+
+                                       <div style="width: 100%;
+                      display: inline-block;
+                      padding: 10px;
+                      background-color: #f5f5f5; text-align:center; margin-bottom: 10px;">
+
+                       <img src="http://mzayat.com/images/red-x-mark-4-icon-free-red-x-mark-icons-red-x-clipart-512_512.gif" width="35" height="35"  style="margin-top: 10px;"">
+
+                      <!--  -->
+                                          <p style="margin-top: 15px;"><b style="border: none;
+                      outline: none!important;
+                      font-size: 26px;
+                      line-height: 18px;
+                      padding: 0;
+                      margin-right: 8px;">Your Display has gone offline!</b>
+                                          <p>Your Display <b>DISPLAYNAME</b>
+                              has lost its connection on <br/>
+                              <span>TIMESTAMP</span>
+
+                                             <p>Display ID: <span>DISPLAYID</span></p>
+
+                                      </div>
+
+                                      <p></p>
+                                      <div style="margin-bottom:16px;text-align:center!important" align="center"><a href="http://install-versions.risevision.com/installer-win-32.exe" style="background:#47b767;border:none;border-radius:3px;color:#fff;display:inline-block;font-size:14px;font-weight:bold;outline:none!important;padding:12px 35px;text-decoration:none" target="_blank">View Display Details</a></div>
+
+
+                                        <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left"></p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">
+                                     You can find common reasons for a Display losing its connection in the <a href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank">Help Center</a>.
+                                     </p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">If you have any questions at all, just reply to this email. &nbsp;We’re here to help!</p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">Thank you,
+                                        <br>Rise Vision Support Team</p>
+                                  </td>
+                              </tr>
+                              <tr>
+                              </tr>
+
+                          </tbody>
+                      </table>
+
+                  </td>
+              </tr>
+          </tbody>
+      </table>
+      <table width="100%" align="middle" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+          <tbody>
+
+              <tr>
+                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:0">
+                      <table cellspacing="0" border="0" cellpadding="0" align="center" width="600" bgcolor="transparent" style="border-collapse:separate;border-spacing:0;font-family:Helvetica,Arial,sans-serif;letter-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px; padding:21px 30px 15px; text-align:center" align="center">
+                                      <p style="color:#b7b7b7;font-size:12px;font-weight:300;margin:0 0 6px;text-decoration:none">Rise Vision 545 King Street West Toronto, Ontario Canada M5V 1M1
+                                      </p>
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </td>
+              </tr>
+               <tr>
+                  <td ><div style="margin: 8px 0; text-align:center!important" align="center"><a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID" style="font-family:Helvetica,Arial,sans-serif;color:#b7b7b7;font-size:12px;font-weight:300; padding:21px 30px 15px; text-align:center" align="center" target="_blank">Unsubscribe from receiving future notifications for this Display</a></div>
+                  </td>
+                </tr>
+          </tbody>
+      </table>
+  </div>
+
+</body>
+</html>

--- a/src/templates/monitor-offline-email.html
+++ b/src/templates/monitor-offline-email.html
@@ -40,7 +40,7 @@
                       margin-right: 8px;">Your Display has gone offline!</b>
                                           <p>Your Display <b>DISPLAYNAME</b>
                               has lost its connection on <br/>
-                              <span>TIMESTAMP</span>
+                              <span>FORMATTEDTIMESTAMP</span>
 
                                              <p>Display ID: <span>DISPLAYID</span></p>
 

--- a/src/templates/monitor-online-email.html
+++ b/src/templates/monitor-online-email.html
@@ -42,7 +42,7 @@
                       margin-right: 8px;">Your Display is back online!</b>
                                           <p>Your Display <b>DISPLAYNAME</b>
                               resumed its connection on <br/>
-                              <span>TIMESTAMP</span>
+                              <span>FORMATTEDTIMESTAMP</span>
 
                                              <p>Display ID: <span>DISPLAYID</span></p>
 

--- a/src/templates/monitor-online-email.html
+++ b/src/templates/monitor-online-email.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width"/>
+</head>
+<body>
+  <div style="background:#f9f9f9;margin:0px;padding:20px" bgcolor="f9f9f9">
+      <table cellspacing="0" border="0" cellpadding="0" align="center" width="595" bgcolor="white" style="border-collapse:separate;border-spacing:0;font-family:Helvetica,Arial,sans-serif;letter-spacing:0;table-layout:fixed">
+          <tbody>
+              <tr>
+                  <td style="border:1px solid #dddddd;border-radius:2px;font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:40px 60px">
+                      <table width="100%" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:0;text-align:center" align="left">
+                                      <img src="https://ci4.googleusercontent.com/proxy/tIn39Uu_-8P30B-NjHrQ6M6cn10CNDo8yKsbzHxTVxQDdshB0RN9KmjFHpgXqGvxfJy7jhFQFRMnvpkBo-cGxyTaPHX-YnB8cvvmC5v4FbYHFSbiRAgMRCOGqol3psI81bf9vVzerfYrewyW=s0-d-e1-ft#http://s3.amazonaws.com/Rise-Images/UI/logo.svg" width="165" height="62" style="padding:15px 0 30px;text-align:left" class="CToWUd">
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                      <table width="100%" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="color:#525252;font-family:Helvetica,Arial,sans-serif;font-size:15px;line-height:22px;padding:0">
+
+
+
+                                       <div style="width: 100%;
+                      display: inline-block;
+                      padding: 10px;
+                      background-color: #f5f5f5; text-align:center; margin-bottom: 10px;">
+
+                       <img src="https://static1.squarespace.com/static/597aa449d482e9e56c97117c/t/59e6cc69a9db0951565bdd72/1508297874678/green+checkmark+Large.png?format=300w" width="35" height="35"  style="margin-top: 10px;"">
+
+                      <!--  -->
+                                          <p style="margin-top: 15px;"><b style="border: none;
+                      outline: none!important;
+                      font-size: 26px;
+                      line-height: 18px;
+                      padding: 0;
+                      margin-right: 8px;">Your Display is back online!</b>
+                                          <p>Your Display <b>DISPLAYNAME</b>
+                              resumed its connection on <br/>
+                              <span>TIMESTAMP</span>
+
+                                             <p>Display ID: <span>DISPLAYID</span></p>
+
+                                      </div>
+
+                                      <p></p>
+                                      <div style="margin-bottom:16px;text-align:center!important" align="center"><a href="http://install-versions.risevision.com/installer-win-32.exe" style="background:#47b767;border:none;border-radius:3px;color:#fff;display:inline-block;font-size:14px;font-weight:bold;outline:none!important;padding:12px 35px;text-decoration:none" target="_blank">View Display Details</a></div>
+
+                                        <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left"></p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">
+                                     You can find common reasons for a Display losing its connection in the <a href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank">Help Center</a>.
+                                     </p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">If you have any questions at all, just reply to this email. &nbsp;We’re here to help!</p>
+                                     <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">Thank you,
+                                        <br>Rise Vision Support Team</p>
+                                  </td>
+                              </tr>
+                              <tr>
+                              </tr>
+
+                          </tbody>
+                      </table>
+                  </td>
+              </tr>
+          </tbody>
+      </table>
+      <table width="100%" align="middle" style="border-collapse:separate;border-spacing:0;table-layout:fixed">
+          <tbody>
+
+              <tr>
+                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px;padding:0">
+                      <table cellspacing="0" border="0" cellpadding="0" align="center" width="600" bgcolor="transparent" style="border-collapse:separate;border-spacing:0;font-family:Helvetica,Arial,sans-serif;letter-spacing:0;table-layout:fixed">
+                          <tbody>
+                              <tr>
+                                  <td style="font-family:Helvetica,Arial,sans-serif;font-size:16px; padding:21px 30px 15px; text-align:center" align="center">
+                                      <p style="color:#b7b7b7;font-size:12px;font-weight:300;margin:0 0 6px;text-decoration:none">Rise Vision 545 King Street West Toronto, Ontario Canada M5V 1M1
+                                      </p>
+                                  </td>
+                              </tr>
+                          </tbody>
+                      </table>
+                  </td>
+              </tr>
+               <tr>
+                  <td ><div style="margin: 8px 0; text-align:center!important" align="center"><a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID" style="font-family:Helvetica,Arial,sans-serif;color:#b7b7b7;font-size:12px;font-weight:300; padding:21px 30px 15px; text-align:center" align="center" target="_blank">Unsubscribe from receiving future notifications for this Display</a></div>
+                  </td>
+                </tr>
+          </tbody>
+      </table>
+  </div>
+
+</body>
+</html>

--- a/src/templates/recovery.txt
+++ b/src/templates/recovery.txt
@@ -1,3 +1,0 @@
-The display with display id 'DISPLAYID' has come back online.
-
-If you no longer wish to receive these notices, you can <a href="https://rvaserver2.appspot.com/monitoring/unsubscribe?email=EMAIL&id=DISPLAYID>unsubscribe</a>.

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "max-lines": "off",
+    "max-statements": "off"
+  }
+}

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -80,9 +80,8 @@ describe("Main - Integration", () => {
         assert(!notifier.sendRecoveryEmail.called);
 
         assert.equal(notifier.sendFailureEmail.callCount, 1);
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args, [
-          'DEF', ['d@example.com']
-        ]);
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
           'ABC': {state: 'FAILED', count: 2},
@@ -110,9 +109,8 @@ describe("Main - Integration", () => {
         assert(!notifier.sendRecoveryEmail.called);
 
         assert.equal(notifier.sendFailureEmail.callCount, 2);
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args, [
-          'GHI', ['g@example.com']
-        ]);
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
           'ABC': {state: 'OK', count: 1},
@@ -151,9 +149,8 @@ describe("Main - Integration", () => {
         assert.equal(notifier.sendFailureEmail.callCount, 2);
 
         assert.equal(notifier.sendRecoveryEmail.callCount, 1);
-        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args, [
-          'GHI', ['g@example.com']
-        ]);
+        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
           'ABC': {state: 'OK', count: 1},

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -24,13 +24,22 @@ describe("Main - Integration", () => {
   it("should iterate and notify accordingly", done => {
     simple.mock(runner, "readMonitoredDisplays").resolveWith([
       {
-        displayId: 'ABC', displayName: 'Main Hall', addresses: ['a@example.com']
+        displayId: 'ABC',
+        displayName: 'Main Hall',
+        timeZoneOffset: -360,
+        addresses: ['a@example.com']
       },
       {
-        displayId: 'DEF', displayName: 'Corridor', addresses: ['d@example.com']
+        displayId: 'DEF',
+        displayName: 'Corridor',
+        timeZoneOffset: -360,
+        addresses: ['d@example.com']
       },
       {
-        displayId: 'GHI', displayName: 'Back door', addresses: ['g@example.com']
+        displayId: 'GHI',
+        displayName: 'Back door',
+        timeZoneOffset: -360,
+        addresses: ['g@example.com']
       }
     ]);
 
@@ -80,8 +89,9 @@ describe("Main - Integration", () => {
         assert(!notifier.sendRecoveryEmail.called);
 
         assert.equal(notifier.sendFailureEmail.callCount, 1);
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].timeZoneOffset, -360);
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -110,8 +120,9 @@ describe("Main - Integration", () => {
         assert(!notifier.sendRecoveryEmail.called);
 
         assert.equal(notifier.sendFailureEmail.callCount, 2);
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
-        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
+        assert.equal(notifier.sendFailureEmail.lastCall.args[0].timeZoneOffset, -360);
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -151,8 +162,9 @@ describe("Main - Integration", () => {
         assert.equal(notifier.sendFailureEmail.callCount, 2);
 
         assert.equal(notifier.sendRecoveryEmail.callCount, 1);
-        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
-        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
+        assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+        assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
+        assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].timeZoneOffset, -360);
         assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -24,13 +24,13 @@ describe("Main - Integration", () => {
   it("should iterate and notify accordingly", done => {
     simple.mock(runner, "readMonitoredDisplays").resolveWith([
       {
-        displayId: 'ABC', addresses: ['a@example.com']
+        displayId: 'ABC', displayName: 'Main Hall', addresses: ['a@example.com']
       },
       {
-        displayId: 'DEF', addresses: ['d@example.com']
+        displayId: 'DEF', displayName: 'Corridor', addresses: ['d@example.com']
       },
       {
-        displayId: 'GHI', addresses: ['g@example.com']
+        displayId: 'GHI', displayName: 'Back door', addresses: ['g@example.com']
       }
     ]);
 
@@ -81,6 +81,7 @@ describe("Main - Integration", () => {
 
         assert.equal(notifier.sendFailureEmail.callCount, 1);
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -110,6 +111,7 @@ describe("Main - Integration", () => {
 
         assert.equal(notifier.sendFailureEmail.callCount, 2);
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+        assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
         assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -150,6 +152,7 @@ describe("Main - Integration", () => {
 
         assert.equal(notifier.sendRecoveryEmail.callCount, 1);
         assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+        assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
         assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {

--- a/test/integration/notifier.js
+++ b/test/integration/notifier.js
@@ -23,13 +23,22 @@ describe("Notifier - Integration", () => {
     // first iteration, one display online, two offline
     return notifier.updateDisplayStatusListAndNotify([
       {
-        displayId: 'ABC', online: true, addresses: ['a@example.com']
+        displayId: 'ABC',
+        displayName: 'Main Hall',
+        online: true,
+        addresses: ['a@example.com']
       },
       {
-        displayId: 'DEF', online: false, addresses: ['d@example.com']
+        displayId: 'DEF',
+        displayName: 'Corridor',
+        online: false,
+        addresses: ['d@example.com']
       },
       {
-        displayId: 'GHI', online: false, addresses: ['g@example.com']
+        displayId: 'GHI',
+        displayName: 'Back door',
+        online: false,
+        addresses: ['g@example.com']
       }
     ])
     .then(() => {
@@ -64,13 +73,22 @@ describe("Notifier - Integration", () => {
       // ABC continues offline, DEF two periods offline now, GHI back and offline
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: false, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: false,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: false, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: false,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: false, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: false,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -79,6 +97,7 @@ describe("Notifier - Integration", () => {
 
       assert.equal(notifier.sendFailureEmail.callCount, 1);
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -90,13 +109,22 @@ describe("Notifier - Integration", () => {
       // ABC goes online, DEF still offline, GHI still offline
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: true, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: true,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: false, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: false,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: false, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: false,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -115,13 +143,22 @@ describe("Notifier - Integration", () => {
       // ABC still online, DEF goes online, GHI offline for two periods now
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: true, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: true,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: true, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: true,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: false, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: false,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -130,6 +167,7 @@ describe("Notifier - Integration", () => {
 
       assert.equal(notifier.sendFailureEmail.callCount, 2);
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -141,13 +179,22 @@ describe("Notifier - Integration", () => {
       // ABC goes offline, DEF still online, GHI goes online again
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: false, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: false,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: true, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: true,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: true, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: true,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -164,13 +211,22 @@ describe("Notifier - Integration", () => {
       // ABC still offline, DEF goes back offline, GHI still online
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: false, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: false,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: false, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: false,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: true, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: true,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -187,13 +243,22 @@ describe("Notifier - Integration", () => {
       // ABC back online, DEF still offline, GHI two periods now in online recovering
       return notifier.updateDisplayStatusListAndNotify([
         {
-          displayId: 'ABC', online: true, addresses: ['a@example.com']
+          displayId: 'ABC',
+          displayName: 'Main Hall',
+          online: true,
+          addresses: ['a@example.com']
         },
         {
-          displayId: 'DEF', online: false, addresses: ['d@example.com']
+          displayId: 'DEF',
+          displayName: 'Corridor',
+          online: false,
+          addresses: ['d@example.com']
         },
         {
-          displayId: 'GHI', online: true, addresses: ['g@example.com']
+          displayId: 'GHI',
+          displayName: 'Back door',
+          online: true,
+          addresses: ['g@example.com']
         }
       ]);
     })
@@ -202,6 +267,7 @@ describe("Notifier - Integration", () => {
 
       assert.equal(notifier.sendRecoveryEmail.callCount, 1);
       assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
       assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {

--- a/test/integration/notifier.js
+++ b/test/integration/notifier.js
@@ -78,9 +78,8 @@ describe("Notifier - Integration", () => {
       assert(!notifier.sendRecoveryEmail.called);
 
       assert.equal(notifier.sendFailureEmail.callCount, 1);
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args, [
-        'DEF', ['d@example.com']
-      ]);
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
         'ABC': {state: 'FAILED', count: 2},
@@ -130,9 +129,8 @@ describe("Notifier - Integration", () => {
       assert(!notifier.sendRecoveryEmail.called);
 
       assert.equal(notifier.sendFailureEmail.callCount, 2);
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args, [
-        'GHI', ['g@example.com']
-      ]);
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
         'ABC': {state: 'OK', count: 1},
@@ -203,9 +201,8 @@ describe("Notifier - Integration", () => {
       assert.equal(notifier.sendFailureEmail.callCount, 2);
 
       assert.equal(notifier.sendRecoveryEmail.callCount, 1);
-      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args, [
-        'GHI', ['g@example.com']
-      ]);
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
         'ABC': {state: 'OK', count: 1},

--- a/test/integration/notifier.js
+++ b/test/integration/notifier.js
@@ -26,18 +26,21 @@ describe("Notifier - Integration", () => {
         displayId: 'ABC',
         displayName: 'Main Hall',
         online: true,
+        timeZoneOffset: -360,
         addresses: ['a@example.com']
       },
       {
         displayId: 'DEF',
         displayName: 'Corridor',
         online: false,
+        timeZoneOffset: -360,
         addresses: ['d@example.com']
       },
       {
         displayId: 'GHI',
         displayName: 'Back door',
         online: false,
+        timeZoneOffset: -360,
         addresses: ['g@example.com']
       }
     ])
@@ -76,18 +79,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -96,8 +102,9 @@ describe("Notifier - Integration", () => {
       assert(!notifier.sendRecoveryEmail.called);
 
       assert.equal(notifier.sendFailureEmail.callCount, 1);
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].timeZoneOffset, -360);
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -112,18 +119,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -146,18 +156,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -166,8 +179,9 @@ describe("Notifier - Integration", () => {
       assert(!notifier.sendRecoveryEmail.called);
 
       assert.equal(notifier.sendFailureEmail.callCount, 2);
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayId, 'GHI');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Back door');
+      assert.equal(notifier.sendFailureEmail.lastCall.args[0].timeZoneOffset, -360);
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {
@@ -182,18 +196,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -214,18 +231,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -246,18 +266,21 @@ describe("Notifier - Integration", () => {
           displayId: 'ABC',
           displayName: 'Main Hall',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['a@example.com']
         },
         {
           displayId: 'DEF',
           displayName: 'Corridor',
           online: false,
+          timeZoneOffset: -360,
           addresses: ['d@example.com']
         },
         {
           displayId: 'GHI',
           displayName: 'Back door',
           online: true,
+          timeZoneOffset: -360,
           addresses: ['g@example.com']
         }
       ]);
@@ -266,8 +289,9 @@ describe("Notifier - Integration", () => {
       assert.equal(notifier.sendFailureEmail.callCount, 2);
 
       assert.equal(notifier.sendRecoveryEmail.callCount, 1);
-      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
-      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
+      assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+      assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
+      assert.equal(notifier.sendRecoveryEmail.lastCall.args[0].timeZoneOffset, -360);
       assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
 
       assert.deepEqual(stateManager.getCurrentDisplayStates(), {

--- a/test/manual/send_email.js
+++ b/test/manual/send_email.js
@@ -6,6 +6,8 @@ if (recipients.length === 0) {
   throw new Error("No recipient addresses provided");
 }
 
-notifier.sendFailureEmail("ABC", recipients)
+const display = {displayId: 'ABC', displayName: 'Main Hall'}
+
+notifier.sendFailureEmail(display, recipients)
 .then(console.log)
 .catch(console.error);

--- a/test/manual/send_email.js
+++ b/test/manual/send_email.js
@@ -6,7 +6,9 @@ if (recipients.length === 0) {
   throw new Error("No recipient addresses provided");
 }
 
-const display = {displayId: 'ABC', displayName: 'Main Hall'}
+const display = {
+  displayId: 'ABC', displayName: 'Main Hall', timeZoneOffset: -360
+};
 
 notifier.sendFailureEmail(display, recipients)
 .then(console.log)

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -10,12 +10,15 @@ const stateManager = require("../../src/state-manager.js");
 
 describe("Notifier - Unit", () => {
 
+  afterEach(() => simple.restore());
+
   describe("Dates", () => {
     it("should get the display date with server date GMT-0400 and display date GMT-0600", () => {
-      const display = {timeZoneOffset: -360};
       const serverDate = new Date(Date.parse('14 Mar 2018 10:00:00 GMT-0400'));
+      simple.mock(notifier, "getServerDate").returnWith(serverDate);
 
-      const displayDate = notifier.displayDateFor(display, serverDate);
+      const display = {timeZoneOffset: -360};
+      const displayDate = notifier.displayDateFor(display);
 
       assert.equal(displayDate.getDate(), 14);
       assert.equal(displayDate.getHours(), 8);
@@ -23,10 +26,11 @@ describe("Notifier - Unit", () => {
     });
 
     it("should get the display date with server date GMT and display date GMT-0600", () => {
-      const display = {timeZoneOffset: -360};
       const serverDate = new Date(Date.parse('14 Mar 2018 10:00:00 GMT'));
+      simple.mock(notifier, "getServerDate").returnWith(serverDate);
 
-      const displayDate = notifier.displayDateFor(display, serverDate);
+      const display = {timeZoneOffset: -360};
+      const displayDate = notifier.displayDateFor(display);
 
       assert.equal(displayDate.getDate(), 14);
       assert.equal(displayDate.getHours(), 4);
@@ -38,8 +42,6 @@ describe("Notifier - Unit", () => {
     beforeEach(() => {
       simple.mock(stateManager, "filterUnmonitoredDisplays").returnWith();
     });
-
-    afterEach(() => simple.restore());
 
     it("exists", ()=>{
       assert(notifier);

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -38,6 +38,33 @@ describe("Notifier - Unit", () => {
     });
   });
 
+  describe("Templates", () => {
+    it("should replace display data", () => {
+      const serverDate = new Date(Date.parse('14 Mar 2018 10:00:00 GMT'));
+      simple.mock(notifier, "getServerDate").returnWith(serverDate);
+
+      const display = {
+        displayId: 'ABC', displayName: 'Main Hall', timeZoneOffset: -240
+      };
+
+      const template = `
+        Display id: DISPLAYID,
+        name: DISPLAYNAME,
+        timestamp: FORMATTEDTIMESTAMP
+      `;
+
+      const displayDate = notifier.displayDateFor(display);
+      const formatted =
+        notifier.replaceDisplayData(template, display, displayDate);
+
+      assert.equal(formatted, `
+        Display id: ABC,
+        name: Main Hall,
+        timestamp: Mar 14 2018, at 06:00AM
+      `);
+    });
+  });
+
   describe("Email functions", () => {
     beforeEach(() => {
       const serverDate = new Date(Date.parse('14 Mar 2018 10:00:00 GMT'));

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -89,7 +89,7 @@ describe("Notifier - Unit", () => {
 
       const parameters = querystring.parse(parameterString);
 
-      assert.equal(parameters.from, "support@risevision.com");
+      assert.equal(parameters.from, "monitor@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'b@example.com');
       assert.equal(parameters.subject, "Display monitoring for display ABC");
@@ -121,7 +121,7 @@ describe("Notifier - Unit", () => {
 
       const parameters = querystring.parse(parameterString);
 
-      assert.equal(parameters.from, "support@risevision.com");
+      assert.equal(parameters.from, "monitor@risevision.com");
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'd@example.com');
       assert.equal(parameters.subject, "Display monitoring for display DEF");

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -35,13 +35,22 @@ describe("Notifier - Unit", () => {
 
     return notifier.updateDisplayStatusListAndNotify([
       {
-        displayId: 'ABC', online: true, addresses: ['a@example.com']
+        displayId: 'ABC',
+        displayName: 'Main Hall',
+        online: true,
+        addresses: ['a@example.com']
       },
       {
-        displayId: 'DEF', online: false, addresses: ['d@example.com']
+        displayId: 'DEF',
+        displayName: 'Corridor',
+        online: false,
+        addresses: ['d@example.com']
       },
       {
-        displayId: 'GHI', online: true, addresses: ['g@example.com']
+        displayId: 'GHI',
+        displayName: 'Back door',
+        online: true,
+        addresses: ['g@example.com']
       }
     ])
     .then(() => {
@@ -60,11 +69,13 @@ describe("Notifier - Unit", () => {
       assert(notifier.sendFailureEmail.called);
       assert.equal(notifier.sendFailureEmail.callCount, 1);
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayName, 'Corridor');
       assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
       assert(notifier.sendRecoveryEmail.called);
       assert.equal(notifier.sendRecoveryEmail.callCount, 1);
       assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayName, 'Back door');
       assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
     });
   });
@@ -75,7 +86,7 @@ describe("Notifier - Unit", () => {
       body: '{"success": true}'
     });
 
-    const display = {displayId: 'ABC'};
+    const display = {displayId: 'ABC', displayName: 'Main Hall'};
 
     return notifier.sendFailureEmail(display, ['a@example.com', 'b@example.com'])
     .then(() => {
@@ -100,6 +111,7 @@ describe("Notifier - Unit", () => {
       assert(options.body);
       assert.equal(typeof options.body.text, "string");
       assert(options.body.text.indexOf("ABC") > 0);
+      assert(options.body.text.indexOf("Main Hall") > 0);
     });
   });
 
@@ -109,7 +121,7 @@ describe("Notifier - Unit", () => {
       body: '{"success": true}'
     });
 
-    const display = {displayId: 'DEF'};
+    const display = {displayId: 'DEF', displayName: 'Corridor'};
 
     return notifier.sendRecoveryEmail(display, ['d@example.com'])
     .then(() => {
@@ -134,6 +146,7 @@ describe("Notifier - Unit", () => {
       assert(options.body);
       assert.equal(typeof options.body.text, "string");
       assert(options.body.text.indexOf("DEF") > 0);
+      assert(options.body.text.indexOf("Corridor") > 0);
     });
   });
 

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -59,15 +59,13 @@ describe("Notifier - Unit", () => {
 
       assert(notifier.sendFailureEmail.called);
       assert.equal(notifier.sendFailureEmail.callCount, 1);
-      assert.deepEqual(notifier.sendFailureEmail.lastCall.args, [
-        'DEF', ['d@example.com']
-      ]);
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[0].displayId, 'DEF');
+      assert.deepEqual(notifier.sendFailureEmail.lastCall.args[1], ['d@example.com']);
 
       assert(notifier.sendRecoveryEmail.called);
       assert.equal(notifier.sendRecoveryEmail.callCount, 1);
-      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args, [
-        'GHI', ['g@example.com']
-      ]);
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[0].displayId, 'GHI');
+      assert.deepEqual(notifier.sendRecoveryEmail.lastCall.args[1], ['g@example.com']);
     });
   });
 
@@ -77,7 +75,9 @@ describe("Notifier - Unit", () => {
       body: '{"success": true}'
     });
 
-    return notifier.sendFailureEmail('ABC', ['a@example.com', 'b@example.com'])
+    const display = {displayId: 'ABC'};
+
+    return notifier.sendFailureEmail(display, ['a@example.com', 'b@example.com'])
     .then(() => {
       assert(got.post.called);
       assert.equal(got.post.callCount, 2);
@@ -109,7 +109,9 @@ describe("Notifier - Unit", () => {
       body: '{"success": true}'
     });
 
-    return notifier.sendRecoveryEmail('DEF', ['d@example.com'])
+    const display = {displayId: 'DEF'};
+
+    return notifier.sendRecoveryEmail(display, ['d@example.com'])
     .then(() => {
       assert(got.post.called);
       assert.equal(got.post.callCount, 1);

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -163,7 +163,7 @@ describe("Notifier - Unit", () => {
 
         const parameters = querystring.parse(parameterString);
 
-        assert.equal(parameters.from, "monitor@risevision.com");
+        assert.equal(parameters.from, "support@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'b@example.com');
         assert.equal(parameters.subject, "Display monitoring for display ABC");
@@ -199,7 +199,7 @@ describe("Notifier - Unit", () => {
 
         const parameters = querystring.parse(parameterString);
 
-        assert.equal(parameters.from, "monitor@risevision.com");
+        assert.equal(parameters.from, "support@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'd@example.com');
         assert.equal(parameters.subject, "Display monitoring for display DEF");

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -82,7 +82,7 @@ describe("Notifier - Unit", () => {
       assert(got.post.called);
       assert.equal(got.post.callCount, 2);
 
-      const url = got.post.lastCall.args[0];
+      const [url, options] = got.post.lastCall.args;
 
       const [resource, parameterString] = url.split('?');
       assert.equal(resource, "https://rvaserver2.appspot.com/_ah/api/rise/v0/email");
@@ -93,8 +93,13 @@ describe("Notifier - Unit", () => {
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'b@example.com');
       assert.equal(parameters.subject, "Display monitoring for display ABC");
-      assert.equal(typeof parameters.text, "string");
-      assert(parameters.text.indexOf("ABC") > 0);
+      assert(!parameters.text);
+
+      assert.equal(typeof options, "object");
+      assert(options.json);
+      assert(options.body);
+      assert.equal(typeof options.body.text, "string");
+      assert(options.body.text.indexOf("ABC") > 0);
     });
   });
 
@@ -109,7 +114,7 @@ describe("Notifier - Unit", () => {
       assert(got.post.called);
       assert.equal(got.post.callCount, 1);
 
-      const url = got.post.lastCall.args[0];
+      const [url, options] = got.post.lastCall.args;
 
       const [resource, parameterString] = url.split('?');
       assert.equal(resource, "https://rvaserver2.appspot.com/_ah/api/rise/v0/email");
@@ -120,8 +125,13 @@ describe("Notifier - Unit", () => {
       assert.equal(parameters.fromName, "Rise Vision Support");
       assert.equal(parameters.recipients, 'd@example.com');
       assert.equal(parameters.subject, "Display monitoring for display DEF");
-      assert.equal(typeof parameters.text, "string");
-      assert(parameters.text.indexOf("DEF") > 0);
+      assert(!parameters.text);
+
+      assert.equal(typeof options, "object");
+      assert(options.json);
+      assert(options.body);
+      assert.equal(typeof options.body.text, "string");
+      assert(options.body.text.indexOf("DEF") > 0);
     });
   });
 


### PR DESCRIPTION
Added UX template with display name and date formatted according to display's timezone.

Also corrected sender email: https://trello.com/c/HPCjo8P7/4042-display-monitoring-server-issue-20

I could manually test emails being sent but started receiving 503 errors from email service just before Share and Learn. The only thing I couldn't manually test was the email being sent with the formatted date, but it's in the unit / integration tests.
