### PR TITLE
Use correct database key for connectivity

### DIFF
--- a/src/connection-state-retriever.js
+++ b/src/connection-state-retriever.js
@@ -13,7 +13,7 @@ module.exports = {
   retrieveState(ids) {
     if (!validParam(ids)) {return invalidParam();}
 
-    const commands = ids.map(displayId=>["sismember", "connections:id", displayId]);
+    const commands = ids.map(displayId=>["get", `connections:id:${displayId}`]);
 
     return redisClient.batch(commands);
   }

--- a/src/redis-promise.js
+++ b/src/redis-promise.js
@@ -4,7 +4,7 @@ const {promisify} = require("util");
 module.exports = {
   connectWith(host) {
     const client = redis.createClient({host});
-    const cmds = ["quit", "del", "sadd", "smembers"];
+    const cmds = ["quit", "del", "sadd", "smembers", "set"];
 
     return cmds.reduce((obj, key)=>{
       return {...obj, [key]: promisify(client[key]).bind(client)};


### PR DESCRIPTION
Since the out-of-order disconnect fix on messaging server, the key to
track display connections has changed. It was a set, and now it is a
simple string key that auto-expires.