### PR TITLE
Feature/change from email to support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing. 
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -3,7 +3,7 @@ const stateManager = require("./state-manager");
 const templates = require("./templates");
 const emailSender = require("./email-sender");
 
-const SENDER_ADDRESS = "monitor@risevision.com";
+const SENDER_ADDRESS = "support@risevision.com";
 const SENDER_NAME = "Rise Vision Support";
 const ONE_MINUTE = 60000;
 

--- a/src/templates/monitor-offline-email.html
+++ b/src/templates/monitor-offline-email.html
@@ -49,15 +49,6 @@
 
 
                                         <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left"></p>
-                      <div style="width: 100%;
-                      display: inline-block;
-                      padding: 10px;
-                      background-color: #fff0d1; text-align:left; margin-bottom: 10px;">
-
-                        <p><b>Pending change to how notifications are delivered to you</b></p>
-
-                        <p>On November 5th, 2019, Display Monitor will be updated to send you notifications from <b>support@risevision.com</b> instead of <b>monitor@risevision.com</b>.</p><p>If you use email filters to route notifications from Display Monitor please update your systems accordingly by November 4th, 2019.</p> 
-                      </div>
                                      <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">
                                      You can find common reasons for a Display losing its connection in the <a href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank">Help Center</a>.
                                      </p>

--- a/src/templates/monitor-online-email.html
+++ b/src/templates/monitor-online-email.html
@@ -46,15 +46,6 @@
                                       <div style="margin-bottom:16px;text-align:center!important" align="center"><a href="https://apps.risevision.com/displays/details/DISPLAYID" style="background:#47b767;border:none;border-radius:3px;color:#fff;display:inline-block;font-size:14px;font-weight:bold;outline:none!important;padding:12px 35px;text-decoration:none" target="_blank">View Display Details</a></div>
 
                                         <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left"></p>
-                      <div style="width: 100%;
-                      display: inline-block;
-                      padding: 10px;
-                      background-color: #fff0d1; text-align:left; margin-bottom: 10px;">
-
-                        <p><b>Pending change to how notifications are delivered to you</b></p>
-
-                        <p>On November 5th, 2019, Display Monitor will be updated to send you notifications from <b>support@risevision.com</b> instead of <b>monitor@risevision.com</b>.</p><p>If you use email filters to route notifications from Display Monitor please update your systems accordingly by November 4th, 2019.</p>
-                      </div>
                                      <p style="line-height:1.5;margin:0 0 17px;text-align:left!important" align="left">
                                      You can find common reasons for a Display losing its connection in the <a href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank">Help Center</a>.
                                      </p>

--- a/test/unit/email-sender.js
+++ b/test/unit/email-sender.js
@@ -15,7 +15,7 @@ describe("Email Sender - Unit", () => {
     });
 
     const parameters = {
-      from: "monitor@risevision.com",
+      from: "support@risevision.com",
       fromName: "Rise Vision Support",
       recipients: "b@example.com",
       subject: "Main Hall disconnected and is now offline"
@@ -32,7 +32,7 @@ describe("Email Sender - Unit", () => {
 
         const queryParams = querystring.parse(parameterString);
 
-        assert.equal(queryParams.from, "monitor@risevision.com");
+        assert.equal(queryParams.from, "support@risevision.com");
         assert.equal(queryParams.fromName, "Rise Vision Support");
         assert.equal(queryParams.recipients, 'b@example.com');
         assert.equal(queryParams.subject, "Main Hall disconnected and is now offline");

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -125,7 +125,7 @@ describe("Notifier - Unit", () => {
 
         const [parameters, content] = emailSender.send.lastCall.args;
 
-        assert.equal(parameters.from, "monitor@risevision.com");
+        assert.equal(parameters.from, "support@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'b@example.com');
         assert.equal(parameters.subject, "Main Hall disconnected and is now offline");
@@ -152,7 +152,7 @@ describe("Notifier - Unit", () => {
 
         const [parameters, content] = emailSender.send.lastCall.args;
 
-        assert.equal(parameters.from, "monitor@risevision.com");
+        assert.equal(parameters.from, "support@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'd@example.com');
         assert.equal(parameters.subject, "Corridor reconnected and is now online");


### PR DESCRIPTION
This changes the email sender from monitor@risevision.com to support@risevision.com per https://trello.com/c/erWOyN4g/5468-2-change-display-monitoring-email-to-supportrisevisioncom

## How Has This Been Tested?
 - Unit tests updated and passing
 - manual test sent to confirm email format is correct and sender is **support@risevision.com**

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

