### PR TITLE
Revert "Send emails from support instead of monitor"

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -3,7 +3,7 @@ const stateManager = require("./state-manager");
 const templates = require("./templates");
 const emailSender = require("./email-sender");
 
-const SENDER_ADDRESS = "support@risevision.com";
+const SENDER_ADDRESS = "monitor@risevision.com";
 const SENDER_NAME = "Rise Vision Support";
 const ONE_MINUTE = 60000;
 

--- a/test/unit/email-sender.js
+++ b/test/unit/email-sender.js
@@ -15,7 +15,7 @@ describe("Email Sender - Unit", () => {
     });
 
     const parameters = {
-      from: "support@risevision.com",
+      from: "monitor@risevision.com",
       fromName: "Rise Vision Support",
       recipients: "b@example.com",
       subject: "Main Hall disconnected and is now offline"
@@ -32,7 +32,7 @@ describe("Email Sender - Unit", () => {
 
         const queryParams = querystring.parse(parameterString);
 
-        assert.equal(queryParams.from, "support@risevision.com");
+        assert.equal(queryParams.from, "monitor@risevision.com");
         assert.equal(queryParams.fromName, "Rise Vision Support");
         assert.equal(queryParams.recipients, 'b@example.com');
         assert.equal(queryParams.subject, "Main Hall disconnected and is now offline");

--- a/test/unit/notifier.js
+++ b/test/unit/notifier.js
@@ -125,7 +125,7 @@ describe("Notifier - Unit", () => {
 
         const [parameters, content] = emailSender.send.lastCall.args;
 
-        assert.equal(parameters.from, "support@risevision.com");
+        assert.equal(parameters.from, "monitor@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'b@example.com');
         assert.equal(parameters.subject, "Main Hall disconnected and is now offline");
@@ -152,7 +152,7 @@ describe("Notifier - Unit", () => {
 
         const [parameters, content] = emailSender.send.lastCall.args;
 
-        assert.equal(parameters.from, "support@risevision.com");
+        assert.equal(parameters.from, "monitor@risevision.com");
         assert.equal(parameters.fromName, "Rise Vision Support");
         assert.equal(parameters.recipients, 'd@example.com');
         assert.equal(parameters.subject, "Corridor reconnected and is now online");


### PR DESCRIPTION
Reverting - Too many auto-responder tickets coming into suppor@risevision.com
