### PR TITLE
Accept match on abbreviated weekday in schedule

### DIFF
--- a/src/queries/displaysToBeMonitored.bq
+++ b/src/queries/displaysToBeMonitored.bq
@@ -31,6 +31,11 @@ create temporary function currentWeekDay(offset FLOAT64)
     as (format_timestamp('%A', timestamp_add(current_timestamp(), interval CAST(offset as INT64) minute)));
     --as ('Friday');
 
+create temporary function currentWeekDayAbbrev(offset FLOAT64)
+  returns STRING
+    as (format_timestamp('%a', timestamp_add(current_timestamp(), interval CAST(offset as INT64) minute)));
+    --as ('Fri');
+
 create temporary function currentTime(offset FLOAT64)
   returns TIME
     as (time_add(current_time(), interval CAST(offset as INT64) minute));
@@ -136,7 +141,7 @@ select
   weekDay.active,
   monitoringEmails,
   timeZoneOffset,
-  ((weekDay.active = true and weekDay.day = currentWeekDay(0)) or (weekDay.active is null and weekDay.day is null)) and
+  ((weekDay.active = true and weekDay.day in (currentWeekDay(0), currentWeekDayAbbrev(0))) or (weekDay.active is null and weekDay.day is null)) and
   ((startTime <= currentTime(0) or startTime is null) and (currentTime(0) <= endTime or endTime is null)) shouldBePingedNow
 from
 (


### PR DESCRIPTION
Fixes issue #53.

## Description
Updates query to match on both full weekday names and abbreviated weekday names.

## Motivation and Context
See #53 

## How Has This Been Tested?
Confirmed query returns True as expected for [QEDW67R7R6HA](https://apps.risevision.com/displays/details/QEDW67R7R6HA?cid=a9f28926-f0d5-4ab5-972d-c875ab70ad8a) when the offset is applied with the fix, and does not return true with the offset applied without the fix.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
