### PR TITLE
Fix/persist display states

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - setup_remote_docker
       - run: docker load < ./dockerImage.tar
       - run: gcloud docker -- push ${DOCKER_IMAGE_NAME}
-      - run: kubectl patch deployment monitoring-server -p '{"spec":{"template":{"spec":{"containers":[{"name":"monitoring-server","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
+      - run: kubectl patch statefulset display-monitoring-server -p '{"spec":{"template":{"spec":{"containers":[{"name":"display-monitoring-server","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
 
   "prod":
     docker: *DOCKERIMAGE
@@ -69,7 +69,7 @@ jobs:
       - run: gcloud config set project $PROJECT_ID
       - run: gcloud --quiet container clusters get-credentials messaging-service-prod
       - run: echo "Releasing ${CIRCLE_SHA1}"
-      - run: kubectl patch deployment monitoring-server -p '{"spec":{"template":{"spec":{"containers":[{"name":"monitoring-server","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
+      - run: kubectl patch statefulset display-monitoring-server -p '{"spec":{"template":{"spec":{"containers":[{"name":"display-monitoring-server","image":"'"$DOCKER_IMAGE_NAME"':'"${CIRCLE_SHA1}"'"}]}}}}'
 
 workflows:
   version: 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,7 @@
         "consistent-return": "off",
         "consistent-this": "error",
         "curly": "error",
-        "default-case": "error",
+        "default-case": "off",
         "dot-location": "off",
         "dot-notation": [
             "error",
@@ -166,7 +166,7 @@
         "no-shadow": "error",
         "no-shadow-restricted-names": "error",
         "no-spaced-func": "error",
-        "no-sync": "error",
+        "no-sync": "off",
         "no-tabs": "error",
         "no-template-curly-in-string": "error",
         "no-ternary": "off",

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ typings/
 # redis db
 dump.rdb
 /.project
+
+saved-states.json

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ function monitorDisplays() {
       logger.log(`Status list generated: ${JSON.stringify(statusList)}`);
 
       return notifier.updateDisplayStatusListAndNotify(statusList);
-    });
+    })
+    .then(stateManager.persistCurrentDisplayStates);
   })
   .catch(console.error);
 }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ const runner = require("./src/query-runner");
 const stateRetriever = require("./src/connection-state-retriever");
 const stateManager = require("./src/state-manager");
 
-const MINUTES = 60000;
-const monitoringInterval = 5 * MINUTES; // eslint-disable-line no-magic-numbers
+const MINUTE_MS = 60000;
+const CYCLE_MINS = 5;
+const monitoringInterval = CYCLE_MINS * MINUTE_MS;
 
 process.on("SIGUSR2", logger.debugToggle);
 Error.stackTraceLimit = 50;
@@ -61,7 +62,7 @@ function run(schedule = setInterval) {
 module.exports = {generateStatusList, monitorDisplays, run};
 
 if (process.env.NODE_ENV !== "test") {
-  console.log(`Monitoring at ${monitoringInterval / MINUTES} minute intervals`);
+  console.log(`Monitoring at ${monitoringInterval / MINUTE_MS} minute intervals`);
   stateRetriever.init();
   run();
 }

--- a/index.js
+++ b/index.js
@@ -64,5 +64,7 @@ module.exports = {generateStatusList, monitorDisplays, run};
 if (process.env.NODE_ENV !== "test") {
   console.log(`Monitoring at ${monitoringInterval / MINUTE_MS} minute intervals`);
   stateRetriever.init();
+  stateManager.init();
+
   run();
 }

--- a/src/state-manager.js
+++ b/src/state-manager.js
@@ -1,7 +1,9 @@
-/* eslint-disable no-magic-numbers, default-case */
-
 // Display ids are used as keys, the value is a structure with state and count of times it has been in that status
+const logger = require("./logger");
+const DATA_PATH = process.env.DATA_PATH || __dirname;
 const TRANSITION_THRESHOLD = 2;
+const PERSIST_FILE_PATH = require("path").join(DATA_PATH, "saved-states.json");
+const fs = require("fs");
 
 let currentDisplayStates = {};
 
@@ -74,14 +76,25 @@ function getCurrentDisplayStates() {
   return currentDisplayStates;
 }
 
-// For testing purposes only.
-function reset() {
-  currentDisplayStates = {};
+function setCurrentDisplayStates(states = {}) {
+  currentDisplayStates = Object.assign({}, states);
+}
+
+function init() {
+  try {
+    module.exports.setCurrentDisplayStates(require(PERSIST_FILE_PATH));
+    logger.log(`Loaded ${Object.keys(currentDisplayStates).length} display states.`);
+  } catch (err) {
+    logger.log(`No saved states loaded from: ${PERSIST_FILE_PATH}`);
+    logger.log(err);
+  }
+
 }
 
 module.exports = {
+  init,
   filterUnmonitoredDisplays,
   updateDisplayStatus,
   getCurrentDisplayStates,
-  reset
+  setCurrentDisplayStates,
 };

--- a/src/state-manager.js
+++ b/src/state-manager.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-magic-numbers, default-case */
 
 // Display ids are used as keys, the value is a structure with state and count of times it has been in that status
+const TRANSITION_THRESHOLD = 2;
+
 let currentDisplayStates = {};
 
 function filterUnmonitoredDisplays(list) {
@@ -26,7 +28,7 @@ function updateAsOnline(entry) {
     case 'ALERTED': return change(entry, 'RECOVERING');
     case 'FAILED': return change(entry, 'OK');
     case 'RECOVERING':
-      if (entry.count >= 2) {
+      if (entry.count >= TRANSITION_THRESHOLD) {
         change(entry, 'OK');
         return "SEND_RECOVERY_EMAIL";
       }
@@ -42,7 +44,7 @@ function updateAsOffline(entry) {
     case 'OK': return change(entry, 'FAILED');
     case 'RECOVERING': return change(entry, 'ALERTED');
     case 'FAILED':
-      if (entry.count >= 2) {
+      if (entry.count >= TRANSITION_THRESHOLD) {
         change(entry, 'ALERTED');
         return "SEND_FAILURE_EMAIL";
       }
@@ -68,7 +70,6 @@ function updateDisplayStatus(displayId, online) {
   return online ? updateAsOnline(displayState) : updateAsOffline(displayState);
 }
 
-// For inspection during testing only.
 function getCurrentDisplayStates() {
   return currentDisplayStates;
 }

--- a/src/state-manager.js
+++ b/src/state-manager.js
@@ -80,6 +80,10 @@ function setCurrentDisplayStates(states = {}) {
   currentDisplayStates = Object.assign({}, states);
 }
 
+function persistCurrentDisplayStates() {
+  fs.writeFileSync(PERSIST_FILE_PATH, JSON.stringify(currentDisplayStates));
+}
+
 function init() {
   try {
     module.exports.setCurrentDisplayStates(require(PERSIST_FILE_PATH));
@@ -97,4 +101,5 @@ module.exports = {
   updateDisplayStatus,
   getCurrentDisplayStates,
   setCurrentDisplayStates,
+  persistCurrentDisplayStates
 };

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -18,7 +18,7 @@ describe("Main - Integration", () => {
 
   afterEach(() => {
     simple.restore();
-    stateManager.reset();
+    stateManager.setCurrentDisplayStates({});
   });
 
   let JKLScheduled = false;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -69,6 +69,8 @@ describe("Main - Integration", () => {
       Promise.resolve(states.shift())
     );
 
+    simple.mock(stateManager, "persistCurrentDisplayStates").returnWith();
+
     monitoring.run((action, interval) => {
       assert.equal(interval, 300000);
 
@@ -89,6 +91,7 @@ describe("Main - Integration", () => {
       .then(() => {
         assert(!notifier.sendFailureEmail.called);
         assert(!notifier.sendRecoveryEmail.called);
+        assert(stateManager.persistCurrentDisplayStates.called);
 
         assert.deepEqual(stateManager.getCurrentDisplayStates(), {
           'ABC': {state: 'FAILED', count: 1},

--- a/test/integration/notifier.js
+++ b/test/integration/notifier.js
@@ -15,7 +15,7 @@ describe("Notifier - Integration", () => {
 
   afterEach(() => {
     simple.restore();
-    stateManager.reset();
+    stateManager.setCurrentDisplayStates({});
   });
 
   it("should notify or not depending on the current display state", () => {

--- a/test/unit/state-manager.js
+++ b/test/unit/state-manager.js
@@ -4,7 +4,7 @@ const stateManager = require("../../src/state-manager.js");
 
 describe("State Manager - Unit", () => {
 
-  afterEach(() => stateManager.reset());
+  afterEach(() => stateManager.setCurrentDisplayStates({}));
 
   it("should filter states not present in current list", () => {
     stateManager.updateDisplayStatus("A123", true);
@@ -352,4 +352,11 @@ describe("State Manager - Unit", () => {
     }
   });
 
+  it("should set display states", ()=>{
+    stateManager.setCurrentDisplayStates(undefined);
+    assert.deepEqual(stateManager.getCurrentDisplayStates(), {});
+
+    stateManager.setCurrentDisplayStates({one: 1});
+    assert.deepEqual(stateManager.getCurrentDisplayStates(), {one: 1});
+  });
 });


### PR DESCRIPTION
## Description
Persists state so that duplicate emails are not sent when the pod is restarted.

## Motivation and Context
Display Monitoring sends duplicate offline notification emails whenever it is restarted.

## How Has This Been Tested?
Unit+local stage

## Release Plan:
The circle CI jobs in this PR have been changed to update the new StatefulSet pod, not the existing Display Monitoring Server. So this merge will not affect the production server.

See https://github.com/Rise-Vision/gke-messaging-service-configs/pull/23 for the production rollout plan.