### PR TITLE
Any non null value should be considered connected

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ let timerId = null;
 
 function generateStatusList(displays, states) {
   return displays.map((display, index) => {
-    const online = states[index] === "1";
+    const online = states[index] !== null;
 
     return Object.assign({online}, display);
   });

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -55,14 +55,14 @@ describe("Main - Integration", () => {
     ]));
 
     const states = [
-      ["1", 0, 0],
-      [0, 0, "1", 0],
-      [0, 0, 0],
-      ["1", 0, 0, 0],
-      ["1", "1", 0, "1"],
-      [0, "1", "1"],
-      [0, 0, "1"],
-      ["1", 0, "1"]
+      ["1", null, null],
+      [null, null, "1", null],
+      [null, null, null],
+      ["1", null, null, null],
+      ["1", "1", null, "1"],
+      [null, "1", "1"],
+      [null, null, "1"],
+      ["1", null, "1"]
     ];
 
     simple.mock(stateRetriever, "retrieveState").callFn(() =>
@@ -204,6 +204,11 @@ describe("Main - Integration", () => {
 
         done();
       })
+      .catch(err=>{
+        console.error(`ERROR on ${err.operator}`);
+        console.log("Actual:", err.actual, "Expected:", err.expected);
+        console.log(err.stack)
+      });
     });
   });
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -17,7 +17,7 @@ describe("Main - Unit", () => {
       }
     ];
 
-    const statusList = monitoring.generateStatusList(displays, ["1", 0, "1"]);
+    const statusList = monitoring.generateStatusList(displays, ["1", null, "1"]);
 
     assert.deepEqual(statusList, [
       {
@@ -45,7 +45,7 @@ describe("Main - Unit", () => {
       }
     ];
 
-    const statusList = monitoring.generateStatusList(displays, [0, 0, 0]);
+    const statusList = monitoring.generateStatusList(displays, [null, null, null]);
 
     assert.deepEqual(statusList, [
       {


### PR DESCRIPTION
## Description
Since MS is [no longer](https://github.com/Rise-Vision/messaging-service/pull/88) setting "1" as the conection key value, the monitoring server should accept any non null value as connected.

## Motivation and Context
Fixes issue with display monitoring showing all displays offline

## How Has This Been Tested?
integration tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
