### PR TITLE
Bypass state / email updates during mass outage

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const logger = require("./src/logger");
 const notifier = require("./src/notifier");
 const runner = require("./src/query-runner");
 const stateRetriever = require("./src/connection-state-retriever");
+const massOutageBypass = require("./src/mass-outage-bypass");
 const stateManager = require("./src/state-manager");
 
 const MINUTE_MS = 60000;
@@ -42,6 +43,11 @@ function monitorDisplays() {
     return stateRetriever.retrieveState(displaysForPresenceCheck)
     .then(states => {
       logger.log(`States retrieved: ${JSON.stringify(states)}`);
+
+      if (massOutageBypass.shouldBypass(states)) {
+        return logger.log(`Bypassing state update due to mass outage`);
+      }
+
       const statusList = generateStatusList(displaysForPresenceCheck, states);
       logger.log(`Status list generated: ${JSON.stringify(statusList)}`);
 

--- a/src/mass-outage-bypass.js
+++ b/src/mass-outage-bypass.js
@@ -1,0 +1,15 @@
+const logger = require("./logger");
+const MASS_OUTAGE_THRESHOLD = 0.2;
+
+module.exports = {
+  shouldBypass(states = []) {
+    const total = states.length;
+    const offlineCount = states.reduce((sum, state)=>{
+      return state === null ? sum + 1 : sum;
+    }, 0);
+
+    logger.log(`Offline count: ${offlineCount} of ${total}`);
+
+    return offlineCount / total >= MASS_OUTAGE_THRESHOLD;
+  }
+};

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -8,6 +8,7 @@ const notifier = require("../../src/notifier");
 const runner = require("../../src/query-runner");
 const stateManager = require("../../src/state-manager");
 const stateRetriever = require("../../src/connection-state-retriever");
+const massOutageBypass = require("../../src/mass-outage-bypass");
 
 describe("Main - Integration", () => {
 
@@ -70,6 +71,8 @@ describe("Main - Integration", () => {
     );
 
     simple.mock(stateManager, "persistCurrentDisplayStates").returnWith();
+
+    simple.mock(massOutageBypass, "shouldBypass").returnWith(false);
 
     monitoring.run((action, interval) => {
       assert.equal(interval, 300000);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,6 +1,10 @@
+const simple = require("simple-mock");
 const assert = require("assert");
-
 const monitoring = require("../../index");
+
+const notifier = require("../../src/notifier");
+const queryRunner = require("../../src/query-runner");
+const stateRetriever = require("../../src/connection-state-retriever");
 
 describe("Main - Unit", () => {
 
@@ -60,4 +64,23 @@ describe("Main - Unit", () => {
     ]);
   });
 
+  it("should bypass updating state and notifying during mass outage", () => {
+    const states = [null, null, null, "abab"];
+    simple.mock(queryRunner, "readMonitoredDisplays").resolveWith([{}]);
+    simple.mock(stateRetriever, "retrieveState").resolveWith(states);
+    simple.mock(notifier, "updateDisplayStatusListAndNotify").returnWith();
+
+    return monitoring.monitorDisplays()
+    .then(()=>assert.equal(notifier.updateDisplayStatusListAndNotify.callCount, 0));
+  });
+
+  it("should not bypass updating state and notifying during regular outage", () => {
+    const states = [null, "abab", "abab", "abab", "abab", "abab"];
+    simple.mock(queryRunner, "readMonitoredDisplays").resolveWith([{}]);
+    simple.mock(stateRetriever, "retrieveState").resolveWith(states);
+    simple.mock(notifier, "updateDisplayStatusListAndNotify").returnWith();
+
+    return monitoring.monitorDisplays()
+    .then(()=>assert.equal(notifier.updateDisplayStatusListAndNotify.callCount, 1));
+  });
 });


### PR DESCRIPTION
## Description
This ensures we don't send out hundreds of emails when there is a
disruption on our end.

We will also add a monitoring alert to ensure that we are notified when
this bypass is triggered.

See [doc](https://docs.google.com/document/d/1dSYoAMVQetmvLVUT8qER53pevS_jST5h5D3qp4EdcaU/edit#heading=h.4j25vuwzxglk).

Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing. 

## Motivation and Context
Disruption reduction

## How Has This Been Tested?
Unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
