### PR TITLE
Increase mass outage bypass threshold

### DIFF
--- a/src/mass-outage-bypass.js
+++ b/src/mass-outage-bypass.js
@@ -1,5 +1,5 @@
 const logger = require("./logger");
-const MASS_OUTAGE_THRESHOLD = 0.2;
+const MASS_OUTAGE_THRESHOLD = 0.4;
 
 module.exports = {
   shouldBypass(states = []) {


### PR DESCRIPTION
## Description
Roughly 30% of displays are offline normally, so the bypass sensitivity
needs to be changed otherwise we're always bypassing.

## Motivation and Context
Bypass functionality

## How Has This Been Tested?
Unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
