### PR TITLE
Change mass outage threshold

### DIFF
--- a/src/mass-outage-bypass.js
+++ b/src/mass-outage-bypass.js
@@ -1,5 +1,5 @@
 const logger = require("./logger");
-const MASS_OUTAGE_THRESHOLD = 0.4;
+const MASS_OUTAGE_THRESHOLD = 0.5;
 
 module.exports = {
   shouldBypass(states = []) {


### PR DESCRIPTION
## Description
During the 2am reboot time there are just over 40% of displays that end up triggering a mass outage alert. This changes the threshold from 40% to 50% so that we aren't receiving alerts every morning due to the 2am reboot.

## Motivation and Context
Monitoring improvement

## How Has This Been Tested?
Unit test confirmed working with existing setup.

## Design / Documentation

For changes, a mini-design [should be included] with multiple [considerations] and distribution.

[Documentation] should be updated / created to reflect the post-merge state.

 - [ ] Architecture / Design doc is included (add link)
 - [x] Architecture / Design doc is not included because the change is trivial (eg: Readme update)

 - [ ] Architecture / Design doc has been distributed
 - [x] Architecture / Design doc has not been distributed

 - [x] Documentation has been updated / [created].
 - [ ] Documentation is not needed because the change is trivial (eg: Readme
   update)

[should be included]: https://docs.google.com/document/d/1l-qMt55yYzql9DlwqyPHftUb120f-xNRyK3Rspird2w/edit#heading=h.2g0bwllttzin
[considerations]:
https://docs.google.com/document/d/1T2dpSocnrU-m_judcsBFaHtpJlJeJy3HKuGbZM8VjKk/edit#heading=h.qxdquqe4r6rj
[Documentation]: https://drive.google.com/drive/folders/1E9KK9s56jGvGso43HkPGcft-GgfM9OML?usp=sharing
[created]: https://docs.google.com/document/d/1LD-EKtuVt_J55sbZrVsCKJK2-BMCVITTWh206Yt40zM/edit#