### PR TITLE
point to redis primary

### DIFF
--- a/src/connection-state-retriever.js
+++ b/src/connection-state-retriever.js
@@ -1,5 +1,5 @@
 const redisPromise = require("./redis-promise.js");
-const gkeHostname = "display-ms-redis-master";
+const gkeHostname = "display-ms-redis-primary";
 
 let redisClient = null;
 


### PR DESCRIPTION
## Description
Points to new redis-primary pod 

## Motivation and Context
Plan for redis state retention will result in a new pod for redis.

## How Has This Been Tested?
TBD

## Design / Documentation

For changes, a mini-design [should be included] with multiple [considerations] and distribution.

[Documentation] should be updated / created to reflect the post-merge state.

 - [x] Architecture / Design doc is included (https://docs.google.com/document/d/11ppHdOFX6UAYpiWsbwcp27MH0Sda7wB9QZtKuw8pBlU/edit#heading=h.4gz014cc8krq)
 - [ ] Architecture / Design doc is not included because the change is trivial (eg: Readme update)

 - [x] Architecture / Design doc has been distributed
 - [ ] Architecture / Design doc has not been distributed

 - [x] Documentation has been *created*. The previous doc serves as documentation of the change. The architecture itself does not change
 - [ ] Documentation is not needed because the change is trivial (eg: Readme
   update)

[should be included]: https://docs.google.com/document/d/1l-qMt55yYzql9DlwqyPHftUb120f-xNRyK3Rspird2w/edit#heading=h.2g0bwllttzin
[considerations]:
https://docs.google.com/document/d/1T2dpSocnrU-m_judcsBFaHtpJlJeJy3HKuGbZM8VjKk/edit#heading=h.qxdquqe4r6rj
[Documentation]: https://drive.google.com/drive/folders/1E9KK9s56jGvGso43HkPGcft-GgfM9OML?usp=sharing
